### PR TITLE
Fix the links in the examples section

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,13 +65,13 @@ if not converted:
 
 ## Examples
 
-Check out the [`examples` folder](tree/main/examples) to see how it can be used.
+Check out the [`examples` folder](https://github.com/multani/structlog-gcp/tree/main/examples) to see how it can be used.
 
 * How it should appear in the Google Cloud Logging log explorer:
-  ![](https://raw.githubusercontent.com/multani/structlog-gcp/main/docs/logs.pn)
+  ![](https://raw.githubusercontent.com/multani/structlog-gcp/main/docs/logs.png)
 
 * How it should appear in the Google Cloud Error Reporting dashboard:
-  ![](https://raw.githubusercontent.com/multani/structlog-gcp/docs/errors.png)
+  ![](https://raw.githubusercontent.com/multani/structlog-gcp/main/docs/errors.png)
 
 
 ## Reference


### PR DESCRIPTION
The images in the examples section were not rendering (one was missing a "g" and the other was missing "main" in the path). The examples link in the README also took you to a 404.

This commit corrects those images links and changes the examples link to be fully qualified.