### PR TITLE
Configure the service name and version for error reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,10 @@ Google Logging API is supposed to be done by an external agent.
 
 In particular, this package provides the following configuration by default:
 
-* Logs are formatted as JSON using the [Google Cloud Logging log
-  format](https://cloud.google.com/logging/docs/structured-logging)
-* The [Python standard library's
-  `logging`](https://docs.python.org/3/library/logging.html) log levels are
-  available and translated to their GCP equivalents.
-* Exceptions and `CRITICAL` log messages will be reported into [Google Error
-  Reporting dashboard](https://cloud.google.com/error-reporting/)
+* Logs are formatted as JSON using the [Google Cloud Logging log format](https://cloud.google.com/logging/docs/structured-logging)
+* The [Python standard library's `logging`](https://docs.python.org/3/library/logging.html)
+  log levels are available and translated to their GCP equivalents.
+* Exceptions and `CRITICAL` log messages will be reported into [Google Error Reporting dashboard](https://cloud.google.com/error-reporting/)
 * Additional logger bound arguments will be reported as `labels` in GCP.
 
 
@@ -62,6 +59,27 @@ except:
 if not converted:
     logger.critical("This is not supposed to happen", converted=converted)
 ```
+
+### Errors
+
+Errors are automatically reported to the [Google Error Reporting service](https://cloud.google.com/error-reporting/).
+
+You can configure the service name and the version used during the report with 2 different ways:
+
+* By default, the library assumes to run with Cloud Function environment
+  variables configured, in particular [the `K_SERVICE` and `K_REVISION` variables](https://cloud.google.com/functions/docs/configuring/env-var#runtime_environment_variables_set_automatically).
+* You can also pass the service name and revision at configuration time with:
+
+  ```python
+  import structlog
+  import structlog_gcp
+
+  processors = structlog_gcp.build_processors(
+      service="my-service",
+      version="v1.2.3",
+  )
+  structlog.configure(processors=processors)
+  ```
 
 ## Examples
 

--- a/structlog_gcp/base.py
+++ b/structlog_gcp/base.py
@@ -3,7 +3,10 @@ from structlog.typing import Processor
 from . import errors, processors
 
 
-def build_processors() -> list[Processor]:
+def build_processors(
+    service: str | None = None,
+    version: str | None = None,
+) -> list[Processor]:
     procs = []
 
     procs.extend(processors.CoreCloudLogging().setup())
@@ -11,7 +14,7 @@ def build_processors() -> list[Processor]:
     procs.extend(processors.CodeLocation().setup())
     procs.extend(errors.ReportException().setup())
     procs.extend(errors.ReportError(["CRITICAL"]).setup())
-    procs.append(errors.add_service_context)
+    procs.extend(errors.ServiceContext(service, version).setup())
     procs.extend(processors.FormatAsCloudLogging().setup())
 
     return procs

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,9 +9,7 @@ from . import fakes
 
 
 @pytest.fixture
-def logger():
-    """Setup a logger for testing and return it"""
-
+def mock_logger_env():
     with (
         patch(
             "structlog.processors.CallsiteParameterAdder",
@@ -22,9 +20,17 @@ def logger():
             "structlog.processors.format_exc_info", side_effect=fakes.format_exc_info
         ),
     ):
-        processors = structlog_gcp.build_processors()
-        structlog.configure(processors=processors)
-        logger = structlog.get_logger()
-        yield logger
+        yield
+
+@pytest.fixture
+def logger(mock_logger_env):
+    """Setup a logger for testing and return it"""
+
+    structlog.reset_defaults()
+
+    processors = structlog_gcp.build_processors()
+    structlog.configure(processors=processors)
+    logger = structlog.get_logger()
+    yield logger
 
     structlog.reset_defaults()

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -1,4 +1,9 @@
 import json
+from unittest.mock import patch
+
+import structlog
+
+import structlog_gcp
 
 
 def test_normal(capsys, logger):
@@ -60,3 +65,57 @@ def test_error(capsys, logger):
         "time": "2023-04-01T08:00:00.000000Z",
     }
     assert expected == msg
+
+
+def test_service_context_default(capsys, logger):
+    try:
+        1 / 0
+    except ZeroDivisionError:
+        logger.exception("oh noes")
+
+    msg = json.loads(capsys.readouterr().out)
+
+    assert msg["serviceContext"] == {
+        "service": "unknown service",
+        "version": "unknown version",
+    }
+
+
+@patch.dict("os.environ", {"K_SERVICE": "test-service", "K_REVISION": "test-version"})
+def test_service_context_envvar(capsys, mock_logger_env):
+    processors = structlog_gcp.build_processors()
+    structlog.configure(processors=processors)
+    logger = structlog.get_logger()
+
+    try:
+        1 / 0
+    except ZeroDivisionError:
+        logger.exception("oh noes")
+
+    msg = json.loads(capsys.readouterr().out)
+
+    assert msg["serviceContext"] == {
+        "service": "test-service",
+        "version": "test-version",
+    }
+
+
+def test_service_context_custom(capsys, mock_logger_env):
+    processors = structlog_gcp.build_processors(
+        service="my-service",
+        version="deadbeef",
+    )
+    structlog.configure(processors=processors)
+    logger = structlog.get_logger()
+
+    try:
+        1 / 0
+    except ZeroDivisionError:
+        logger.exception("oh noes")
+
+    msg = json.loads(capsys.readouterr().out)
+
+    assert msg["serviceContext"] == {
+        "service": "my-service",
+        "version": "deadbeef",
+    }


### PR DESCRIPTION
Instead of solely relying on the Cloud Function environment runtime, this allows to configure both the service name and the version, when an error is reported to the Google Error Reporting service.