### PR TITLE
Correctly format extra event keys to have them parsed by Cloud Logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ In particular, this package provides the following configuration by default:
 * The [Python standard library's `logging`](https://docs.python.org/3/library/logging.html)
   log levels are available and translated to their GCP equivalents.
 * Exceptions and `CRITICAL` log messages will be reported into [Google Error Reporting dashboard](https://cloud.google.com/error-reporting/)
-* Additional logger bound arguments will be reported as `labels` in GCP.
+* Additional logger bound arguments will be reported into the `jsonPayload` event.
 
 
 ## How to use?

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -51,7 +51,7 @@ def test_error(stdout, logger):
             "service": "unknown service",
             "version": "unknown version",
         },
-        "logging.googleapis.com/labels": {"foo": "bar"},
+        "foo": "bar",
         "severity": "CRITICAL",
         "message": "oh noes",
         "stack_trace": "oh noes\nTraceback blabla",
@@ -114,13 +114,14 @@ def test_service_context_custom(stdout, mock_logger_env):
     }
 
 
-def test_labels_string(stdout, logger):
+def test_extra_labels(stdout, logger):
     logger.info(
         "test",
         test1="test1",
         test2=2,
-        test3={"foo": "bar"},
-        test4={"date": datetime.date(2023, 1, 1)},
+        test3=False,
+        test4={"foo": "bar"},
+        test5={"date": datetime.date(2023, 1, 1)},
     )
 
     msg = json.loads(stdout())
@@ -131,14 +132,16 @@ def test_labels_string(stdout, logger):
             "function": "test:test123",
             "line": "42",
         },
-        "message": "test",
         "severity": "INFO",
         "time": "2023-04-01T08:00:00.000000Z",
-        "logging.googleapis.com/labels": {
-            "test1": "test1",
-            "test2": "2",
-            "test3": '{"foo": "bar"}',
-            "test4": '{"date": "datetime.date(2023, 1, 1)"}',
-        },
+        "message": "test",
+
+        # This should be parsed automatically by Cloud Logging into dedicated keys and saved into a JSON payload.
+        # See: https://cloud.google.com/logging/docs/structured-logging#special-payload-fields
+        "test1": "test1",
+        "test2": 2,
+        "test3": False,
+        "test4": {"foo": "bar"},
+        "test5": {"date": "datetime.date(2023, 1, 1)"},
     }
     assert expected == msg


### PR DESCRIPTION
Extra keys are not added to `logging.googleapis.com/labels` as it's some kind of special (I'll add a formatter to add extra labels in there).

Instead, the extra keys are simply added as extra JSON keys when formatted to stdout, and they will be picked up by Google Cloud Logging and added as extra keys into the final Cloud Logging event's `jsonPayload` key

Only downside: when there are no extra keys, Cloud Logging simply put the log message into `textPayload` and not into `jsonPayload.message`.