### PR TITLE
Allow custom serializer

### DIFF
--- a/structlog_gcp/processors.py
+++ b/structlog_gcp/processors.py
@@ -43,8 +43,8 @@ class FormatAsCloudLogging:
     See: https://cloud.google.com/logging/docs/structured-logging#special-payload-fields
     """
 
-    def setup(self) -> list[Processor]:
-        return [self, structlog.processors.JSONRenderer()]
+    def setup(self, serializer=None) -> list[Processor]:
+        return [self, structlog.processors.JSONRenderer(serializer=serializer)]
 
     def __call__(
         self, logger: WrappedLogger, method_name: str, event_dict: EventDict


### PR DESCRIPTION
https://www.structlog.org/en/stable/performance.html mentions using a different JSON serializer for performance.

I use the orjson serializer plus a final `decode_bytes` processor.

```py
def decode_bytes(logger: Any, method_name: Any, bs: bytes) -> str:
    """orjson returns bytes."""
    return bs.decode()
```

Fixes: #28