### PR TITLE
Split out the JSON renderer from the Cloud Logging formatter

### DIFF
--- a/structlog_gcp/base.py
+++ b/structlog_gcp/base.py
@@ -1,3 +1,4 @@
+import structlog.processors
 from structlog.typing import Processor
 
 from . import errors, processors
@@ -16,5 +17,5 @@ def build_processors(
     procs.extend(errors.ReportError(["CRITICAL"]).setup())
     procs.extend(errors.ServiceContext(service, version).setup())
     procs.extend(processors.FormatAsCloudLogging().setup())
-
+    procs.append(structlog.processors.JSONRenderer())
     return procs

--- a/structlog_gcp/processors.py
+++ b/structlog_gcp/processors.py
@@ -44,7 +44,7 @@ class FormatAsCloudLogging:
     """
 
     def setup(self) -> list[Processor]:
-        return [self, structlog.processors.JSONRenderer()]
+        return [self]
 
     def __call__(
         self, logger: WrappedLogger, method_name: str, event_dict: EventDict


### PR DESCRIPTION
This separates the concern a bit more and allow to configure specific JSON renderer when there's a need to.

Closes: #28

@petemounce: FYI :)