### PR TITLE
Configure Context Variables processor by default

### DIFF
--- a/structlog_gcp/base.py
+++ b/structlog_gcp/base.py
@@ -1,3 +1,4 @@
+import structlog.contextvars
 import structlog.processors
 from structlog.typing import Processor
 
@@ -21,6 +22,7 @@ def build_processors(
 
     procs: list[Processor] = []
 
+    procs.append(structlog.contextvars.merge_contextvars)
     procs.extend(build_gcp_processors(service, version))
     procs.append(structlog.processors.JSONRenderer())
 


### PR DESCRIPTION
The new default "go-to" processors builder function now configures the [`merge_contextvars()` processor](https://www.structlog.org/en/stable/contextvars.html): it's a good default value to have, but it's not really part of the "GCP-specific" processors and is separated from them.

Fix: #33
Fix: #34