### PR TITLE
Allow to override the log level while logging exceptions

### DIFF
--- a/structlog_gcp/base.py
+++ b/structlog_gcp/base.py
@@ -54,7 +54,7 @@ def build_gcp_processors(
     procs.append(structlog.processors.TimeStamper(fmt="iso"))
     procs.append(processors.init_cloud_logging)
 
-    procs.extend(processors.setup_log_severity())
+    procs.append(processors.LogSeverity())
     procs.extend(processors.setup_code_location())
 
     # Errors: log exceptions

--- a/structlog_gcp/constants.py
+++ b/structlog_gcp/constants.py
@@ -1,0 +1,22 @@
+ERROR_EVENT_TYPE = (
+    "type.googleapis.com/google.devtools.clouderrorreporting.v1beta1.ReportedErrorEvent"
+)
+
+SOURCE_LOCATION_KEY = "logging.googleapis.com/sourceLocation"
+
+CLOUD_LOGGING_KEY = "cloud-logging"
+
+# From Python's logging level to Google level
+# https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#LogSeverity
+SEVERITY_MAPPING = {
+    "notset": "DEFAULT",  # The log entry has no assigned severity level.
+    "debug": "DEBUG",  # Debug or trace information.
+    "info": "INFO",  # Routine information, such as ongoing status or performance.
+    # "notice": "NOTICE", # Normal but significant events, such as start up, shut down, or a configuration change.
+    "warn": "WARNING",  # Warning events might cause problems.
+    "warning": "WARNING",  # Warning events might cause problems.
+    "error": "ERROR",  # Error events are likely to cause problems.
+    "critical": "CRITICAL",  # Critical events cause more severe problems or outages.
+    # "alert": "ALERT", # A person must take an action immediately.
+    # "emergency": "EMERGENCY", #	One or more systems are unusable.
+}

--- a/structlog_gcp/processors.py
+++ b/structlog_gcp/processors.py
@@ -6,11 +6,7 @@
 import structlog.processors
 from structlog.typing import EventDict, Processor, WrappedLogger
 
-from .types import CLOUD_LOGGING_KEY, SOURCE_LOCATION_KEY
-
-
-def setup_log_severity() -> list[Processor]:
-    return [structlog.processors.add_log_level, LogSeverity()]
+from .constants import CLOUD_LOGGING_KEY, SEVERITY_MAPPING, SOURCE_LOCATION_KEY
 
 
 def setup_code_location() -> list[Processor]:
@@ -77,27 +73,14 @@ class LogSeverity:
 
     def __init__(self) -> None:
         self.default = "notset"
-
-        # From Python's logging level to Google level
-        self.mapping = {
-            "notset": "DEFAULT",  # The log entry has no assigned severity level.
-            "debug": "DEBUG",  # Debug or trace information.
-            "info": "INFO",  # Routine information, such as ongoing status or performance.
-            # "notice": "NOTICE", # Normal but significant events, such as start up, shut down, or a configuration change.
-            "warn": "WARNING",  # Warning events might cause problems.
-            "warning": "WARNING",  # Warning events might cause problems.
-            "error": "ERROR",  # Error events are likely to cause problems.
-            "critical": "CRITICAL",  # Critical events cause more severe problems or outages.
-            # "alert": "ALERT", # A person must take an action immediately.
-            # "emergency": "EMERGENCY", #	One or more systems are unusable.
-        }
+        self.mapping = SEVERITY_MAPPING.copy()
 
     def __call__(
         self, logger: WrappedLogger, method_name: str, event_dict: EventDict
     ) -> EventDict:
         """Format a Python log level value as a GCP log severity."""
 
-        log_level = event_dict.pop("level")
+        log_level = method_name
         severity = self.mapping.get(log_level, self.default)
 
         event_dict[CLOUD_LOGGING_KEY]["severity"] = severity

--- a/structlog_gcp/types.py
+++ b/structlog_gcp/types.py
@@ -1,7 +1,0 @@
-ERROR_EVENT_TYPE = (
-    "type.googleapis.com/google.devtools.clouderrorreporting.v1beta1.ReportedErrorEvent"
-)
-
-SOURCE_LOCATION_KEY = "logging.googleapis.com/sourceLocation"
-
-CLOUD_LOGGING_KEY = "cloud-logging"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,10 +31,12 @@ def logger(mock_logger_env: None) -> Generator[WrappedLogger, None, None]:
     """Setup a logger for testing and return it"""
 
     structlog.reset_defaults()
+    structlog.contextvars.clear_contextvars()
 
     processors = structlog_gcp.build_processors()
     structlog.configure(processors=processors)
     logger = structlog.get_logger()
+
     yield logger
 
     structlog.reset_defaults()


### PR DESCRIPTION
While logging information during an exception `except` block, instead of overwriting the log level with `CRITICAL`, the log level used by the caller will be set instead.

This allows the caller to use:

```python
try:
    raise ValueError()
except Exception as exc:
    logger.warn(f"I was expecting this error: {exc}")
```

The log message will be logged as `WARN` level, whereas it was logged as `CRITICAL` before.

The example below show 2 cases:

* One when the `warn` logger was used
* The other one when `error` was used

![Screenshot From 2025-04-13 16-40-57](https://github.com/user-attachments/assets/3c604e69-6dff-4763-ba4e-f4cb39a4f5ea)

Otherwise, with `INFO`, it also correctly sets the log level:
![image](https://github.com/user-attachments/assets/3adcabb4-759d-430d-a46a-1d67b9de5797)


In any case, if an `exception` attribute is still passed to the logger, as in `logger.warn("something", exception=exc)`, the log level will be `WARNING` (as now expected), but the error will also still be correctly reported (in Error Reporting + the bubble in Cloud Logging)

![image](https://github.com/user-attachments/assets/8a53ffaa-c889-43c1-a057-0daf14bbcae0)


Fix #71 