### PR TITLE
Fix error reporting formatting

### DIFF
--- a/structlog_gcp/error_reporting.py
+++ b/structlog_gcp/error_reporting.py
@@ -29,9 +29,7 @@ class ReportException:
         event_dict[CLOUD_LOGGING_KEY]["@type"] = ERROR_EVENT_TYPE
 
         # https://cloud.google.com/error-reporting/docs/formatting-error-messages
-        message = event_dict[CLOUD_LOGGING_KEY]["message"]
-        error_message = f"{message}\n{exception}"
-        event_dict[CLOUD_LOGGING_KEY]["stack_trace"] = error_message
+        event_dict[CLOUD_LOGGING_KEY]["stack_trace"] = exception
 
         return event_dict
 

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -2,7 +2,8 @@
 
 from typing import Collection
 
-from structlog.processors import CallsiteParameter
+from structlog._frames import _format_exception
+from structlog.processors import CallsiteParameter, _figure_out_exc_info
 from structlog.typing import EventDict, WrappedLogger
 
 
@@ -34,7 +35,16 @@ class TimeStamper:
 def format_exc_info(
     logger: WrappedLogger, method_name: str, event_dict: EventDict
 ) -> EventDict:
-    exc_info = event_dict.pop("exc_info", None)
+    exc_info = _figure_out_exc_info(event_dict.pop("exc_info", None))
+
     if exc_info:
-        event_dict["exception"] = "Traceback blabla"
+        exception = _format_exception(exc_info)
+        # Format the exception, but only keep the "Traceback ..." and the
+        # actual exception line, and skip all the rest.
+        # We need to skip the middle lines as they contain the path to the
+        # files, which differs depending on which path the library is tested
+        # from.
+        head = exception.splitlines()[0]
+        tail = exception.splitlines()[-1]
+        event_dict["exception"] = f"{head}\n...\n{tail}"
     return event_dict

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -57,7 +57,7 @@ def test_exception(stdout: T_stdout, logger: WrappedLogger) -> None:
         "foo": "bar",
         "severity": "ERROR",
         "message": "oh noes",
-        "stack_trace": "oh noes\nTraceback blabla",
+        "stack_trace": "Traceback (most recent call last):\n...\nZeroDivisionError: division by zero",
         "time": "2023-04-01T08:00:00.000000Z",
     }
     assert msg == expected
@@ -191,7 +191,7 @@ def test_core_processors_only(
     assert "" == output.err
     msg = output.out.strip()
 
-    # No JSON formmating, no contextvars
+    # No JSON formatting, no contextvars
     expected = "message='test' time='2023-04-01T08:00:00.000000Z' severity='INFO' logging.googleapis.com/sourceLocation={'file': '/app/test.py', 'line': '42', 'function': 'test:test123'}"
 
     assert expected == msg
@@ -225,7 +225,7 @@ def test_exception_different_level(stdout: T_stdout, logger: WrappedLogger) -> N
         },
         "severity": "WARNING",
         "message": "oh no; anyways",
-        "stack_trace": "oh no; anyways\ndivision by zero",
+        "stack_trace": "ZeroDivisionError('division by zero')",
         "time": "2023-04-01T08:00:00.000000Z",
     }
     assert msg == expected


### PR DESCRIPTION
The stacktrace for an error was formatted as:

    ${message}
    ${stacktrace}

I'm pretty sure I saw that documented in Google Cloud's documentation when I initially implemented this feature, but I can't find it anymore and the current documentation from
https://cloud.google.com/error-reporting/docs/formatting-error-messages#log-error now says:

> To log an error event that is a stack trace, write the error event as
> one of these types:
> [...]
>
> * A `jsonPayload` that includes a `message`, `stack_trace`, or
>   `exception` field.
>
>   You can specify more than one of those fields. If more than one of
>   those fields is specified, then the order of evaluation is: `stack_trace`,
>   then `exception`, and then `message`.
>
>   If the `message` field is evaluated and if it isn't empty, then the
>   stack trace is captured only when the field contains a stack trace in
>   one of the supported programming language formats. The stack trace isn't
>   captured by Error Reporting when an unsupported format is used.
>
>   If your error event is formatted as a `ReportedErrorEvent` object,
>   then copy its fields to the `jsonPayload`. For more information and an
>   example, see Log an error that is formatted as a ReportedErrorEvent
>   object.

There's no mention of this weird `${message}\n${stacktrace}` anymore, so let's get rid of it.

Fix: https://github.com/multani/structlog-gcp/issues/96